### PR TITLE
set Access-Control-Allow-Headers to Access-Control-Request-Headers

### DIFF
--- a/src/io/sarnowski/swagger1st/util/api.clj
+++ b/src/io/sarnowski/swagger1st/util/api.clj
@@ -35,12 +35,13 @@
     (let [response (if (and override-options
                             (= :options (:request-method request)))
                      (r/response nil)
-                     (handler request))]
+                     (handler request))
+          request-headers (get-in request [:headers "access-control-request-headers"])]
       (-> response
           (r/header "Access-Control-Allow-Origin" "*")
           (r/header "Access-Control-Max-Age" "3600")
           (r/header "Access-Control-Allow-Methods" "GET, POST, DELETE, PUT, PATCH, OPTIONS")
-          (r/header "Access-Control-Allow-Headers" "*")))))
+          (r/header "Access-Control-Allow-Headers" request-headers)))))
 
 (defn surpress-favicon-requests
   "Returns a 404 for /favicon.ico requests."


### PR DESCRIPTION
(fixes #14)

The Access-Control-Allow-Headers header does not allow wildcards. It
must be an exact match:
http://www.w3.org/TR/cors/#access-control-allow-headers-response-header
