### PR TITLE
Replace deprecated Prismatic/schema either

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
 
                  [circleci/clj-yaml "0.5.5"]
 
-                 [prismatic/schema "1.0.3"]
+                 [prismatic/schema "1.0.4"]
 
                  [clj-time "0.11.0"]
 

--- a/src/io/sarnowski/swagger1st/schemas/swagger_2_0.clj
+++ b/src/io/sarnowski/swagger1st/schemas/swagger_2_0.clj
@@ -11,6 +11,9 @@
 (defn extension? [^String k]
   (.startsWith "x-" k))
 
+(defn ref? [x]
+  (get x "$ref"))
+
 (def primitives
   {"integer" s-long
    "number" s-float
@@ -140,8 +143,8 @@
   {s-string [s-string]})
 
 (def responses-object
-  {(s/optional-key "default")           (s/either response-object reference-object)
-   (s/either s-long s-string)               (s/either response-object reference-object)
+  {(s/optional-key "default")           (s/if ref? reference-object response-object)
+   (s/cond-pre s-long s-string)         (s/if ref? reference-object response-object)
    (s/optional-key (s/pred extension?)) s/Any})
 
 (def operation-object
@@ -153,7 +156,7 @@
    (s/optional-key "externalDocs")      external-documentation-object
    (s/optional-key "consumes")          [s-string]
    (s/optional-key "produces")          [s-string]
-   (s/optional-key "parameters")        [(s/either parameter-object reference-object)]
+   (s/optional-key "parameters")        [(s/if ref? reference-object parameter-object)]
    (s/optional-key "schemes")           [s-string]
    (s/optional-key "deprecated")        s-boolean
    (s/optional-key "security")          [security-requirement-object]
@@ -168,7 +171,7 @@
    (s/optional-key "options")           operation-object
    (s/optional-key "head")              operation-object
    (s/optional-key "patch")             operation-object
-   (s/optional-key "parameters")        [(s/either parameter-object reference-object)]
+   (s/optional-key "parameters")        [(s/if ref? reference-object parameter-object)]
    (s/optional-key (s/pred extension?)) s/Any})
 
 (def paths-object


### PR DESCRIPTION
Hi,

I replaced  #either (deprecated to remove backtracking from prismatic/schema codebase according to https://groups.google.com/forum/#!topic/prismatic-plumbing/RWTc9vuvDcU) with if + precondition.

I also updated schema to 1.0.4 which passes the test suite.

Closes #29 
