### PR TITLE
Changes 'ui-path' from '/ui/' to '/ui'

### DIFF
--- a/src/io/sarnowski/swagger1st/core.clj
+++ b/src/io/sarnowski/swagger1st/core.clj
@@ -38,7 +38,7 @@
   [context & {:keys [discovery-path definition-path ui-path overwrite-host?]
               :or   {discovery-path  "/.well-known/schema-discovery"
                      definition-path "/swagger.json"
-                     ui-path         "/ui/"
+                     ui-path         "/ui"
                      overwrite-host? true}}]
   (chain-handler
     context


### PR DESCRIPTION
the trailing '/' is easy to miss and it doesn't lead to the UI when we miss it. More convenient without it.
