### PR TITLE
Fix date time validation

### DIFF
--- a/src/io/sarnowski/swagger1st/parser.clj
+++ b/src/io/sarnowski/swagger1st/parser.clj
@@ -110,7 +110,7 @@
    "formData" extract-parameter-form
    "body"     extract-parameter-body})
 
-(def date-time-formatter (f/formatters :date-time))
+(def date-time-formatter (f/formatters :date-time-parser))
 (def date-formatter (f/formatters :date))
 (def string-transformers {; basic types
                           "string"    identity

--- a/test/io/sarnowski/swagger1st/integration.clj
+++ b/test/io/sarnowski/swagger1st/integration.clj
@@ -52,13 +52,15 @@
 
          (is (= (app (-> (mock/request :post "/user/123")
                          (mock/header "Content-Type" "application/json; charset=UTF-8")
-                         (mock/body (json/encode {:name "sarnowski"}))))
+                         (mock/body (json/encode {:name "sarnowski"
+                                                  :created "2016-08-29T11:45:09+02:00"}))))
                 {:status 200}))
 
          (is (= (app (mock/request :get "/user/123"))
                 {:status  200
                  :headers {"Content-Type" "application/json"}
-                 :body    (json/encode {:name "sarnowski"})}))
+                 :body    (json/encode {:name "sarnowski"
+                                        :created "2016-08-29T09:45:09.000Z"})}))
 
          (is (= (app (mock/request :delete "/user/123"))
                 {:status 200})))

--- a/test/io/sarnowski/swagger1st/integration.yaml
+++ b/test/io/sarnowski/swagger1st/integration.yaml
@@ -85,6 +85,9 @@ definitions:
       - properties:
           rule:
             type: string
+          created:
+            type: string
+            format: date-time
 
 securityDefinitions:
   userpw_def:

--- a/test/io/sarnowski/swagger1st/parser_test.clj
+++ b/test/io/sarnowski/swagger1st/parser_test.clj
@@ -33,9 +33,23 @@
   (is (= (t/date-time 2015 4 28)
          (parse "2015-04-28" {"type"   "string"
                               "format" "date"})))
-  (is (= (t/date-time 2015 4 28 10 56 12 98)
-         (parse "2015-04-28T12:56:12.098+02:00" {"type"   "string"
-                                                 "format" "date-time"})))
+
+  ; date-times
+
+  (are [date-time-str expected]
+    (= expected (parse date-time-str {"type" "string", "format" "date-time"}))
+
+    "2015-04-28T12:56:12Z" (t/date-time 2015 4 28 12 56 12 0)
+    "2015-04-28T12:56:12.9Z" (t/date-time 2015 4 28 12 56 12 900)
+    "2015-04-28T12:56:12.98Z" (t/date-time 2015 4 28 12 56 12 980)
+    "2015-04-28T12:56:12.987Z" (t/date-time 2015 4 28 12 56 12 987)
+    "2015-04-28T12:56:12.9876Z" (t/date-time 2015 4 28 12 56 12 987)
+    "2015-04-28T12:56:12+02:00" (t/date-time 2015 4 28 10 56 12 0)
+    "2015-04-28T12:56:12.9+02:00" (t/date-time 2015 4 28 10 56 12 900)
+    "2015-04-28T12:56:12.98+02:00" (t/date-time 2015 4 28 10 56 12 980)
+    "2015-04-28T12:56:12.987+02:00" (t/date-time 2015 4 28 10 56 12 987)
+    "2015-04-28T12:56:12.9876+02:00" (t/date-time 2015 4 28 10 56 12 987)
+    )
 
   ; pattern matching
   (is (= "foo" (parse "foo" {"type"    "string"


### PR DESCRIPTION
fixes #43 

This PR changes the date time formatter, which is used to parse the value from the request, to ["date-time-parser"](http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTimeParser%28%29). That one is less strict than the previously used ["date-time"](http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%28%29)
