### PR TITLE
enable multipart parameters

### DIFF
--- a/src/io/sarnowski/swagger1st/parser.clj
+++ b/src/io/sarnowski/swagger1st/parser.clj
@@ -6,7 +6,8 @@
             [io.sarnowski.swagger1st.mapper :refer [split-path]]
             [io.sarnowski.swagger1st.util.api :as api]
             [clj-time.format :as f]
-            [ring.middleware.params :refer [params-request]])
+            [ring.middleware.params :refer [params-request]]
+            [ring.middleware.multipart-params :refer [multipart-params-request]])
   (:import (org.joda.time DateTime)
            (java.io PrintWriter)
            (clojure.lang ExceptionInfo)))
@@ -69,8 +70,11 @@
 
 (defn extract-parameter-form
   "Extract a parameter from the request body form."
-  [{form-params :form-params} definition]
-  (get form-params (get definition "name")))
+  [{:keys [form-params multipart-params]} definition]
+  (let [param-name (get definition "name")]
+    (or
+      (get form-params param-name)
+      (get multipart-params param-name))))
 
 (defn extract-parameter-body
   "Extract a parameter from the request body."
@@ -317,7 +321,7 @@
 (defn parse
   "Executes all prepared functions for the request."
   [{:keys [parsers]} next-handler request]
-  (let [request (params-request request)]
+  (let [request (-> request params-request multipart-params-request)]
     (try
       (let [parameters (->> (get parsers (-> request :swagger :key))
                             ; execute all parsers of the request

--- a/test/io/sarnowski/swagger1st/parser_test.clj
+++ b/test/io/sarnowski/swagger1st/parser_test.clj
@@ -196,6 +196,14 @@
                  "properties" {"foo" {"type" "string"}}}
                 :allow-undefined-keys true))))
 
+(deftest file-values
+  (testing "parameters of type 'file' are just passed through"
+    (let [value {:filename     "screenshot.png",
+                 :content-type "image/png",
+                 :tempfile     :a-file-handle,
+                 :size         84647}]
+      (is (identical? value (parse value {"type" "file"}))))))
+
 (deftest extract-path-parameters
   (is (= "baz"
          (p/extract-parameter-path
@@ -218,11 +226,9 @@
            {"name" "bar"}))))
 
 (deftest extract-form-parameters
-  (is (= "baz"
-         (p/extract-parameter-form
-           {:uri         "/foo"
-            :form-params {"bar" "baz"}}
-           {"name" "bar"}))))
+  (are [request] (= "baz" (p/extract-parameter-form request {"name" "bar"}))
+    {:uri "/foo", :form-params {"bar" "baz"}}
+    {:uri "/foo", :multipart-params {"bar" "baz"}}))
 
 (defn json-body
   "Generates a reader that can be used to read serialized JSON."


### PR DESCRIPTION
- fixes #21
- fixes #18

This Pull Request enables multipart parameters and file uploading. The `"file"` response object type is not yet supported.
