### PR TITLE
Handle empty array parameters

### DIFF
--- a/src/io/sarnowski/swagger1st/parser.clj
+++ b/src/io/sarnowski/swagger1st/parser.clj
@@ -204,7 +204,7 @@
   (let [items-definition (get definition "items")
         items-parser (create-value-parser items-definition path parser-options)]
     (fn [value]
-      (let [vals (split-array definition value)
+      (let [vals (if value (split-array definition value) [])
             err (partial throw-value-error value definition path)
             check-count (fn [value]
                           (if-let [max-items (get definition "maxItems")]

--- a/test/io/sarnowski/swagger1st/parser_test.clj
+++ b/test/io/sarnowski/swagger1st/parser_test.clj
@@ -184,34 +184,42 @@
                          "collectionFormat" "multi"})))
 
   ; collection formats
-  (is (= ["foo"] (parse "foo"
+  (are [collection-format]
+      (= [] (parse nil
+                   {"type"             "array"
+                    "items"            {"type" "string"}
+                    "collectionFormat" collection-format}))
+    "multi" "csv" "ssv" "tsv" "pipes")
+
+  (are [collection-format]
+      (= [""] (parse ""
+                     {"type"             "array"
+                      "items"            {"type" "string"}
+                      "collectionFormat" collection-format}))
+    "multi" "csv" "ssv" "tsv" "pipes")
+
+  (are [collection-format]
+      (= ["foo"] (parse "foo"
                         {"type"             "array"
                          "items"            {"type" "string"}
-                         "collectionFormat" "multi"})))
+                         "collectionFormat" collection-format}))
+    "multi" "csv" "ssv" "tsv" "pipes")
 
   (is (= ["foo" "bar"] (parse "foo,bar"
-                              {"type"             "array"
-                               "items"            {"type" "string"}
-                               "collectionFormat" "csv"})))
-
-  (is (= ["foo" "bar"] (parse "foo,bar"
+                              ;; "csv" should be the default format
                               {"type"             "array"
                                "items"            {"type" "string"}})))
 
-  (is (= ["foo" "bar"] (parse "foo bar"
+  (are [collection-format input]
+      (= ["foo" "bar"] (parse input
                               {"type"             "array"
                                "items"            {"type" "string"}
-                               "collectionFormat" "ssv"})))
-
-  (is (= ["foo" "bar"] (parse "foo\tbar"
-                              {"type"             "array"
-                               "items"            {"type" "string"}
-                               "collectionFormat" "tsv"})))
-
-  (is (= ["foo" "bar"] (parse "foo|bar"
-                              {"type"             "array"
-                               "items"            {"type" "string"}
-                               "collectionFormat" "pipes"}))))
+                               "collectionFormat" collection-format}))
+    "multi"  ["foo" "bar"]
+    "csv"    "foo,bar"
+    "ssv"    "foo bar"
+    "tsv"    "foo\tbar"
+    "pipes"  "foo|bar"))
 
 (deftest object-values
   (is (= {:foo "bar"} (parse {:foo "bar"}


### PR DESCRIPTION
I don't find a clear hint in the Swagger specification as to how the empty string should be interpreted. I decided to view it as an array with a single element rather than the empty array because otherwise there would be no way to specify that value; the empty array can always be expressed by omitting the parameter altogether.

This fixes #56.