### PR TITLE
Hide "Explore" button in Swagger UI

### DIFF
--- a/resources/io/sarnowski/swagger1st/swaggerui/index.html
+++ b/resources/io/sarnowski/swagger1st/swaggerui/index.html
@@ -104,7 +104,9 @@
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
       -->
       <div id='auth_container'></div>
+      <!-- EDITED disabled
       <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
+      -->
     </form>
   </div>
 </div>


### PR DESCRIPTION
The input field for Swagger definition URL is already hidden so this button makes no sense and is confusing to the users.