### PR TITLE
Fix schema vendor extensions

### DIFF
--- a/src/io/sarnowski/swagger1st/schemas/swagger_2_0.clj
+++ b/src/io/sarnowski/swagger1st/schemas/swagger_2_0.clj
@@ -14,12 +14,6 @@
 (defn ref? [x]
   (get x "$ref"))
 
-(def primitives
-  {"integer" s-long
-   "number" s-float
-   "string" s-string
-   "boolean" s-boolean})
-
 ;;; complex types
 
 (def contact-object

--- a/src/io/sarnowski/swagger1st/schemas/swagger_2_0.clj
+++ b/src/io/sarnowski/swagger1st/schemas/swagger_2_0.clj
@@ -1,5 +1,6 @@
 (ns io.sarnowski.swagger1st.schemas.swagger-2-0
-  (:require [schema.core :as s]))
+  (:require [clojure.string :as string]
+            [schema.core :as s]))
 
 ;;; Basic types
 
@@ -8,8 +9,9 @@
 (def s-string s/Str)
 (def s-boolean s/Bool)
 
-(defn extension? [^String k]
-  (.startsWith "x-" k))
+(defn extension? [k]
+  (and (string? k)
+       (string/starts-with? k "x-")))
 
 (defn ref? [x]
   (get x "$ref"))
@@ -26,13 +28,13 @@
    (s/optional-key "url")  s-string})
 
 (def info-object
-  {(s/required-key "title")             s-string
-   (s/required-key "version")           s-string
-   (s/optional-key "description")       s-string
-   (s/optional-key "termsOfService")    s-string
-   (s/optional-key "contact")           contact-object
-   (s/optional-key "license")           license-object
-   (s/optional-key (s/pred extension?)) s/Any})
+  {(s/required-key "title")          s-string
+   (s/required-key "version")        s-string
+   (s/optional-key "description")    s-string
+   (s/optional-key "termsOfService") s-string
+   (s/optional-key "contact")        contact-object
+   (s/optional-key "license")        license-object
+   (s/pred extension?)               s/Any})
 
 (def external-documentation-object
   {(s/required-key "url")         s-string
@@ -98,7 +100,7 @@
    (s/optional-key "externalDocs")     external-documentation-object
    (s/optional-key "example")          s/Any
    (s/optional-key "$ref")             s-string
-   (s/optional-key "x-swagger1st-keywordize") s/Any})
+   (s/pred extension?)                  s/Any})
 
 (def header-object
   (merge
@@ -120,12 +122,12 @@
 (def parameter-object
   (merge
     items-object
-    {(s/required-key "name")              s-string
-     (s/required-key "in")                s-string
-     (s/optional-key "description")       s-string
-     (s/optional-key "required")          s-boolean
-     (s/optional-key "schema")            schema-object
-     (s/optional-key (s/pred extension?)) s/Any}))
+    {(s/required-key "name")        s-string
+     (s/required-key "in")          s-string
+     (s/optional-key "description") s-string
+     (s/optional-key "required")    s-boolean
+     (s/optional-key "schema")      schema-object
+     (s/pred extension?)            s/Any}))
 
 (def parameters-definitions-object
   {s-string parameter-object})
@@ -136,41 +138,41 @@
 (def security-requirement-object
   {s-string [s-string]})
 
+;; TODO: allows extensions
 (def responses-object
   {(s/optional-key "default")           (s/if ref? reference-object response-object)
-   (s/cond-pre s-long s-string)         (s/if ref? reference-object response-object)
-   (s/optional-key (s/pred extension?)) s/Any})
+   (s/cond-pre s-long s-string)         (s/if ref? reference-object response-object)})
 
 (def operation-object
-  {(s/required-key "operationId")       s-string
-   (s/required-key "responses")         responses-object
-   (s/optional-key "tags")              [s-string]
-   (s/optional-key "summary")           s-string
-   (s/optional-key "description")       s-string
-   (s/optional-key "externalDocs")      external-documentation-object
-   (s/optional-key "consumes")          [s-string]
-   (s/optional-key "produces")          [s-string]
-   (s/optional-key "parameters")        [(s/if ref? reference-object parameter-object)]
-   (s/optional-key "schemes")           [s-string]
-   (s/optional-key "deprecated")        s-boolean
-   (s/optional-key "security")          [security-requirement-object]
-   (s/optional-key (s/pred extension?)) s/Any})
+  {(s/required-key "operationId")  s-string
+   (s/required-key "responses")    responses-object
+   (s/optional-key "tags")         [s-string]
+   (s/optional-key "summary")      s-string
+   (s/optional-key "description")  s-string
+   (s/optional-key "externalDocs") external-documentation-object
+   (s/optional-key "consumes")     [s-string]
+   (s/optional-key "produces")     [s-string]
+   (s/optional-key "parameters")   [(s/if ref? reference-object parameter-object)]
+   (s/optional-key "schemes")      [s-string]
+   (s/optional-key "deprecated")   s-boolean
+   (s/optional-key "security")     [security-requirement-object]
+   (s/pred extension?)             s/Any})
 
 (def path-object
-  {(s/optional-key "$ref")              s-string
-   (s/optional-key "get")               operation-object
-   (s/optional-key "put")               operation-object
-   (s/optional-key "post")              operation-object
-   (s/optional-key "delete")            operation-object
-   (s/optional-key "options")           operation-object
-   (s/optional-key "head")              operation-object
-   (s/optional-key "patch")             operation-object
-   (s/optional-key "parameters")        [(s/if ref? reference-object parameter-object)]
-   (s/optional-key (s/pred extension?)) s/Any})
+  {(s/optional-key "$ref")       s-string
+   (s/optional-key "get")        operation-object
+   (s/optional-key "put")        operation-object
+   (s/optional-key "post")       operation-object
+   (s/optional-key "delete")     operation-object
+   (s/optional-key "options")    operation-object
+   (s/optional-key "head")       operation-object
+   (s/optional-key "patch")      operation-object
+   (s/optional-key "parameters") [(s/if ref? reference-object parameter-object)]
+   (s/pred extension?)           s/Any})
 
+;; TODO: allows extensions
 (def paths-object
-  {s-string                               path-object
-   (s/optional-key (s/pred extension?)) s/Any})
+  {s-string path-object})
 
 (def definitions-object
   {s-string schema-object})
@@ -190,24 +192,24 @@
   {s-string s-string})
 
 (def security-scheme-object
-  {(s/required-key "type")              security-scheme-types
-   (s/optional-key "description")       s-string
-   (s/optional-key "name")              s-string
-   (s/optional-key "in")                s-string
-   (s/optional-key "flow")              security-scheme-oauth2-flows
-   (s/optional-key "authorizationUrl")  s-string
-   (s/optional-key "tokenUrl")          s-string
-   (s/optional-key "scopes")            scopes-object
-   (s/optional-key (s/pred extension?)) s/Any})
+  {(s/required-key "type")             security-scheme-types
+   (s/optional-key "description")      s-string
+   (s/optional-key "name")             s-string
+   (s/optional-key "in")               s-string
+   (s/optional-key "flow")             security-scheme-oauth2-flows
+   (s/optional-key "authorizationUrl") s-string
+   (s/optional-key "tokenUrl")         s-string
+   (s/optional-key "scopes")           scopes-object
+   (s/pred extension?)                 s/Any})
 
 (def security-definitions-object
   {s-string security-scheme-object})
 
 (def tag-object
-  {(s/required-key "name")              s-string
-   (s/optional-key "description")       s-string
-   (s/optional-key "externalDocs")      external-documentation-object
-   (s/optional-key (s/pred extension?)) s/Any})
+  {(s/required-key "name")         s-string
+   (s/optional-key "description")  s-string
+   (s/optional-key "externalDocs") external-documentation-object
+   (s/pred extension?)             s/Any})
 
 (def root-object
   {(s/required-key "swagger")             (s/eq "2.0")

--- a/test/io/sarnowski/swagger1st/schemas/schema_test.clj
+++ b/test/io/sarnowski/swagger1st/schemas/schema_test.clj
@@ -36,3 +36,34 @@
 (deftest kio-definition
   (s/validate schema-2-0/root-object
               (load-swagger-definition :yaml-cp "io/sarnowski/swagger1st/schemas/kio.yaml")))
+
+(deftest info-object-extensions
+  (s/validate schema-2-0/info-object {"title"         "minimal schema"
+                                      "version"       "1.0"
+                                      "x-internal-id" 123}))
+
+(deftest schema-object-extensions
+  (s/validate schema-2-0/schema-object {"type" "            string"
+                                        "x-extensible-enum" ["foo" "bar"]}))
+
+(deftest parameter-object-extensions
+  (s/validate schema-2-0/parameter-object {"name"          "id"
+                                           "in"            "path"
+                                           "x-internal-id" 123}))
+
+(deftest operation-object-extensions
+  (s/validate schema-2-0/operation-object {"operationId"   "operation.id"
+                                           "responses"     {"default" {"description" "default response"}}
+                                           "x-internal-id" 123}))
+
+(deftest path-object-extensions
+  (s/validate schema-2-0/path-object {"$ref"          "#/definitions/path"
+                                      "x-internal-id" 123}))
+
+(deftest security-scheme-object-extensions
+  (s/validate schema-2-0/security-scheme-object {"type"          "basic"
+                                                 "x-internal-id" 123}))
+
+(deftest tag-object-extensions
+  (s/validate schema-2-0/tag-object {"name"          "default"
+                                     "x-internal-id" 123}))


### PR DESCRIPTION
The current implementation didn't allow extension properties at all and they were also not tested at all.

I believe it is not possible express definitions for Responses and Paths objects using Schema but I've added TODOs if somebody has an idea how to do it.