### PR TITLE
Fix parsing array values nested in body object

### DIFF
--- a/src/io/sarnowski/swagger1st/parser.clj
+++ b/src/io/sarnowski/swagger1st/parser.clj
@@ -205,7 +205,7 @@
         items-parser (create-value-parser items-definition path parser-options)]
     (fn [value]
       (let [vals (cond
-                   (= "body" (first path)) value
+									 (and (= "body" (first path)) (= 1 (count path))) value
                    (some? value) (split-array definition value)
                    :else [])
             err (partial throw-value-error value definition path)

--- a/test/io/sarnowski/swagger1st/parser_test.clj
+++ b/test/io/sarnowski/swagger1st/parser_test.clj
@@ -239,6 +239,32 @@
     "tsv"    "foo\tbar"
     "pipes"  "foo|bar"))
 
+(deftest nested-array-values
+  (is (= {:words ["foobar"]} (parse-body {:words "foobar"}
+                                         {"type"       "object"
+                                          "required"   ["words"]
+                                          "properties" {"words" {"type"  "array"
+                                                                 "items" {"type" "string"}}}})))
+
+  (is (= {:words ["foobar"]} (parse-body {:words ["foobar"]}
+                                         {"type"       "object"
+                                          "required"   ["words"]
+                                          "properties" {"words" {"type"             "array"
+                                                                 "items"            {"type" "string"}
+                                                                 "collectionFormat" "multi"}}})))
+  (is (= {:words ["foo" "bar"]} (parse-body {:words "foo,bar"}
+                                            {"type"       "object"
+                                             "required"   ["words"]
+                                             "properties" {"words" {"type"  "array"
+                                                                    "items" {"type" "string"}}}})))
+  (is (= {:words [1234]} (parse-body {:words 1234}
+                            {"type"       "object"
+                             "required"   ["words"]
+                             "properties" {"words" {"type"             "array"
+                                                    "items"            {"type" "integer"}
+                                                    "collectionFormat" "multi"}}}))))
+
+
 (deftest object-values
   (is (= {:foo "bar"} (parse {:foo "bar"}
                              {"type"       "object"


### PR DESCRIPTION
Resolves #80 

I added an additional check to account for when the body of a request isn't just an array object, but rather an object with an array parameter. Like {"words":["foo","bar"]} or a csv array {"words":"foo,bar"} that is defined by the schema as 'in: body'. 