### PR TITLE
Fix validation to allow parameter object in parameters

### DIFF
--- a/src/io/sarnowski/swagger1st/validation.clj
+++ b/src/io/sarnowski/swagger1st/validation.clj
@@ -13,7 +13,7 @@
       vals
       (mapcat vals)
       (mapcat #(get % "parameters"))
-      (mapcat vals)
+      (keep #(get % "$ref"))
       (map #(clojure.string/replace % "#/parameters/" ""))
       set)))
 

--- a/test/io/sarnowski/swagger1st/schemas/broken-ref.yaml
+++ b/test/io/sarnowski/swagger1st/schemas/broken-ref.yaml
@@ -10,6 +10,10 @@ paths:
       parameters:
         - $ref: '#/parameters/goodParam'
         - $ref: '#/parameters/badParam'
+        - name: limit
+          in: query
+          description: max records to return
+          type: integer
       responses:
         200:
           description: all fine


### PR DESCRIPTION
Release 0.26.0 has broken validation that doesn't allow Parameter Object in parameters but expects Reference Object. This bug was introduced in https://github.com/zalando-stups/swagger1st/pull/85.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object